### PR TITLE
feat(soccerhub): Phase C — Understat xG pipelines (player, team-match…

### DIFF
--- a/.github/workflows/run-season.yml
+++ b/.github/workflows/run-season.yml
@@ -114,6 +114,42 @@ jobs:
           print(push_club_elo(force=True))
           "
 
+  understat:
+    needs: seasons  # player-xg updates rows the seasons job just wrote
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        league:
+          - "ENG-Premier League"
+          - "ESP-La Liga"
+          - "GER-Bundesliga"
+          - "ITA-Serie A"
+          - "FRA-Ligue 1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e "Soccer Data Hub"
+      - name: refresh understat xg (player, team-match, shots)
+        working-directory: Soccer Data Hub
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # read side of player-xg matching; key is public by design (in site JS)
+          SUPABASE_PUBLISHABLE_KEY: "sb_publishable_Qy0bJ4CdrxffuJGNq12ebw_r0-Z3qD-"
+          LEAGUE: ${{ matrix.league }}
+        run: |
+          python -c "
+          import os
+          from soccerhub import push_player_xg, push_shots, push_team_match
+          lg, ss = os.environ['LEAGUE'], os.environ['SEASON']
+          print('player_xg', push_player_xg(lg, ss, force=True))
+          print('team_match', push_team_match(lg, ss, force=True))
+          print('shots', push_shots(lg, ss, force=True))
+          "
+
   age-curve:
     needs: seasons  # derived from player_season — run after it refreshes
     runs-on: ubuntu-latest

--- a/Soccer Data Hub/src/soccerhub/__init__.py
+++ b/Soccer Data Hub/src/soccerhub/__init__.py
@@ -11,6 +11,7 @@ from soccerhub.readers.transfermarkt import (
     fetch_transfermarkt_transfers,
     fetch_transfermarkt_values,
 )
+from soccerhub.readers.understat import fetch_understat
 from soccerhub.pipelines import (
     build_player_season,
     build_player_xref,
@@ -18,6 +19,9 @@ from soccerhub.pipelines import (
     push_club_elo,
     push_club_elo_history,
     push_matches,
+    push_player_xg,
+    push_shots,
+    push_team_match,
     push_to_supabase,
     push_transfers,
     read_hub,
@@ -43,6 +47,10 @@ __all__ = [
     "push_matches",
     "push_club_elo",
     "push_club_elo_history",
+    "push_player_xg",
+    "push_shots",
+    "push_team_match",
+    "fetch_understat",
     "read_hub",
     "run_season",
 ]

--- a/Soccer Data Hub/src/soccerhub/pipelines/__init__.py
+++ b/Soccer Data Hub/src/soccerhub/pipelines/__init__.py
@@ -17,6 +17,9 @@ __all__ = [
     "push_matches",
     "push_club_elo",
     "push_club_elo_history",
+    "push_player_xg",
+    "push_shots",
+    "push_team_match",
     "read_hub",
     "run_season",
 ]
@@ -24,8 +27,11 @@ __all__ = [
 XREF_CONFLICT_KEY = "league,season,team,fbref_name"
 TRANSFERS_CONFLICT_KEY = "tm_id,transfer_date"  # matches 0002 PK
 AGE_CURVE_CONFLICT_KEY = "primary_position,age"  # matches 0005 PK
-MATCHES_CONFLICT_KEY = "league,season,date,home_team,away_team"  # matches 0007 PK
-CLUB_ELO_CONFLICT_KEY = "team,league,snapshot_date"  # matches 0008 PK
+MATCHES_CONFLICT_KEY = "league,season,date,home_team,away_team"  # matches 0006 PK
+CLUB_ELO_CONFLICT_KEY = "team,league,snapshot_date"  # matches 0007 PK
+CONFLICT_KEY_PLAYER_SEASON = "league,season,team,player_name"  # matches 0001 PK
+TEAM_MATCH_CONFLICT_KEY = "league,season,game_id"  # matches 0009 PK
+SHOTS_CONFLICT_KEY = "league,season,shot_id"  # matches 0010 PK
 BIG5 = {"ENG-Premier League", "ESP-La Liga", "GER-Bundesliga",
         "ITA-Serie A", "FRA-Ligue 1"}
 
@@ -147,3 +153,12 @@ def run_season(
     manifest = build_player_season(league, season, force=force, refetch=force)
     push_to_supabase(manifest, table)
     return manifest
+
+
+# bottom import on purpose: understat.py reads this package's CONFLICT_KEY
+# constants at call time, so importing it here is cycle-free
+from soccerhub.pipelines.understat import (  # noqa: E402
+    push_player_xg,
+    push_shots,
+    push_team_match,
+)

--- a/Soccer Data Hub/src/soccerhub/pipelines/understat.py
+++ b/Soccer Data Hub/src/soccerhub/pipelines/understat.py
@@ -1,0 +1,162 @@
+"""Understat pipelines: xG columns onto player_season + team-match xG table."""
+import pandas as pd
+
+from soccerhub.pipelines.xref import _score, normalize
+from soccerhub.readers.understat import fetch_understat
+
+UNDERSTAT_SINCE = 2014   # no data before 2014-15
+FUZZY_FLOOR = 0.90       # stricter than xref's 0.85: no birth-year guard here
+# minutes should roughly agree between sources for the same player-stint;
+# a bigger gap means we're about to attach the wrong player
+MINUTES_GUARD = 450
+
+XG_COLS = {
+    "xg": "xg", "np_xg": "np_xg", "xa": "xa",
+    "xg_chain": "xg_chain", "xg_buildup": "xg_buildup",
+    "shots": "shots", "key_passes": "key_passes",
+    "player_id": "understat_id",
+}
+
+
+def match_players(us: pd.DataFrame, hub: pd.DataFrame) -> pd.DataFrame:
+    """Understat player-season rows -> hub player_season identities.
+
+    Ladder (Understat has no birth year, so minutes agreement is the guard):
+      1. same normalized name, single row on both sides
+      2. duplicated names (mid-season movers: one row per stint, both
+         sources) paired greedily by closest minutes
+      3. fuzzy name for leftovers, minutes-guarded
+    Returns hub key columns + XG_COLS values for matched rows.
+    """
+    us = us.reset_index(drop=True)
+    hub = hub.reset_index(drop=True)
+    us_norm = us["player"].map(normalize)
+    hub_norm = hub["player_name"].map(normalize)
+    us_min = us["minutes"].fillna(0)
+    hub_min = hub["minutes"].fillna(0)
+
+    pairs: list[tuple[int, int]] = []  # (hub_pos, us_pos)
+    hub_groups = hub.groupby(hub_norm).groups
+    us_groups = us.groupby(us_norm).groups
+
+    for norm, hidx in hub_groups.items():
+        uidx = us_groups.get(norm)
+        if uidx is None:
+            continue
+        hidx, uidx = list(hidx), list(uidx)
+        if len(hidx) == 1 and len(uidx) == 1:
+            pairs.append((hidx[0], uidx[0]))
+            continue
+        # rung 2: same name several times = separate stints; align by minutes
+        remaining = list(uidx)
+        for h in sorted(hidx, key=lambda i: -hub_min[i]):
+            if not remaining:
+                break
+            u = min(remaining, key=lambda i: abs(hub_min[h] - us_min[i]))
+            if abs(hub_min[h] - us_min[u]) <= MINUTES_GUARD:
+                pairs.append((h, u))
+                remaining.remove(u)
+
+    # rung 3: fuzzy leftovers (accent/spelling drift), minutes-guarded
+    used_h = {h for h, _ in pairs}
+    used_u = {u for _, u in pairs}
+    left_h = [i for i in hub.index if i not in used_h]
+    left_u = [i for i in us.index if i not in used_u]
+    for u in left_u:
+        best, best_ratio = None, 0.0
+        for h in left_h:
+            if abs(hub_min[h] - us_min[u]) > MINUTES_GUARD:
+                continue
+            ratio = _score(us_norm[u], hub_norm[h])
+            if ratio > best_ratio:
+                best, best_ratio = h, ratio
+        if best is not None and best_ratio >= FUZZY_FLOOR:
+            pairs.append((best, u))
+            left_h.remove(best)
+
+    if not pairs:
+        return pd.DataFrame(columns=["league", "season", "team", "player_name",
+                                     *XG_COLS.values()])
+    hi = [h for h, _ in pairs]
+    ui = [u for _, u in pairs]
+    out = hub.loc[hi, ["league", "season", "team", "player_name"]].reset_index(drop=True)
+    vals = us.loc[ui, list(XG_COLS)].rename(columns=XG_COLS).reset_index(drop=True)
+    return pd.concat([out, vals], axis=1)
+
+
+def push_player_xg(league: str, season: str, force: bool = False) -> tuple[int, int]:
+    """Understat xG/xA -> existing player_season rows (partial-column upsert).
+
+    Only matched rows are pushed, keyed by the hub's own identity — an
+    unmatched Understat row can never create an orphan. Returns
+    (matched, understat_total).
+    """
+    from soccerhub.pipelines import CONFLICT_KEY_PLAYER_SEASON
+    from soccerhub.pipelines.query import read_hub
+    from soccerhub.pipelines.supa import upsert_df
+
+    if int(season) < UNDERSTAT_SINCE:
+        return (0, 0)
+    us = pd.read_parquet(
+        fetch_understat(league, season, "player_season", force=force).path
+    )
+    hub = read_hub("player_season", select="league,season,team,player_name,minutes",
+                   league=league, season=season)
+    matched = match_players(us, hub)
+    if len(matched):
+        matched = matched.round({c: 3 for c in
+                                 ["xg", "np_xg", "xa", "xg_chain", "xg_buildup"]})
+        upsert_df(matched, "player_season", CONFLICT_KEY_PLAYER_SEASON)
+    return (len(matched), len(us))
+
+
+TEAM_MATCH_COLS = [
+    "game_id", "date", "home_team", "away_team",
+    "home_goals", "away_goals", "home_xg", "away_xg",
+    "home_np_xg", "away_np_xg", "home_expected_points", "away_expected_points",
+    "home_ppda", "away_ppda", "home_deep_completions", "away_deep_completions",
+]
+
+
+def push_team_match(league: str, season: str, force: bool = False) -> int:
+    """Understat per-match team xG -> team_match_understat table."""
+    from soccerhub.pipelines import TEAM_MATCH_CONFLICT_KEY
+    from soccerhub.pipelines.supa import upsert_df
+
+    if int(season) < UNDERSTAT_SINCE:
+        return 0
+    df = pd.read_parquet(
+        fetch_understat(league, season, "team_match", force=force).path
+    )
+    df = df[TEAM_MATCH_COLS].copy()
+    df["date"] = pd.to_datetime(df["date"]).dt.strftime("%Y-%m-%d")
+    df.insert(0, "league", league)
+    df.insert(1, "season", season)  # canonical start year, not understat's code
+    return upsert_df(df, "team_match_understat", TEAM_MATCH_CONFLICT_KEY)
+
+
+SHOT_COLS = [
+    "shot_id", "game_id", "date", "team", "player", "player_id",
+    "assist_player", "assist_player_id", "xg", "location_x", "location_y",
+    "minute", "body_part", "situation", "result",
+]
+
+
+def push_shots(league: str, season: str, force: bool = False) -> int:
+    """Understat shot events -> shots_understat table (~10.5k rows/league-season).
+
+    Upstream is one page per match, so a fresh fetch takes ~3 min per
+    league-season — the slow grain; cron refreshes only the current season.
+    """
+    from soccerhub.pipelines import SHOTS_CONFLICT_KEY
+    from soccerhub.pipelines.supa import upsert_df
+
+    if int(season) < UNDERSTAT_SINCE:
+        return 0
+    df = pd.read_parquet(fetch_understat(league, season, "shots", force=force).path)
+    df = df[SHOT_COLS].copy()
+    df["date"] = pd.to_datetime(df["date"]).dt.strftime("%Y-%m-%d")
+    df["xg"] = df["xg"].round(4)
+    df.insert(0, "league", league)
+    df.insert(1, "season", season)  # canonical start year, not understat's code
+    return upsert_df(df, "shots_understat", SHOTS_CONFLICT_KEY)

--- a/Soccer Data Hub/src/soccerhub/readers/understat.py
+++ b/Soccer Data Hub/src/soccerhub/readers/understat.py
@@ -1,0 +1,32 @@
+"""Understat xG data (plain HTTP, no browser) via soccerdata."""
+import soccerdata as sd
+
+from soccerhub.cache import cached_fetch
+from soccerhub.manifest import Manifest
+from soccerhub.readers.fbref import _season_to_code
+
+DATASETS = {
+    "player_season": "read_player_season_stats",
+    "team_match": "read_team_match_stats",
+    "shots": "read_shot_events",
+}
+
+
+def fetch_understat(league: str, season: str, dataset: str = "player_season",
+                    force: bool = False) -> Manifest:
+    """One league-season of Understat data. Coverage: Big-5 from 2014.
+
+    ``dataset``: player_season (per-player xG/xA totals), team_match
+    (per-match team xG, PPDA, expected points), shots (every shot with
+    coordinates — one page per match upstream, so much slower to fetch).
+    """
+    if dataset not in DATASETS:
+        raise ValueError(f"dataset must be one of {sorted(DATASETS)}")
+
+    def produce():
+        u = sd.Understat(leagues=league, seasons=_season_to_code(season))
+        return getattr(u, DATASETS[dataset])().reset_index()
+
+    return cached_fetch(
+        "understat", dataset, {"league": league, "season": season}, produce, force
+    )

--- a/Soccer Data Hub/supabase/migrations/0008_player_xg.sql
+++ b/Soccer Data Hub/supabase/migrations/0008_player_xg.sql
@@ -1,0 +1,11 @@
+-- Understat xG columns on player_season (2014+ seasons only; earlier stay null).
+-- Apply manually in SQL editor.
+alter table player_season
+    add column if not exists xg real,
+    add column if not exists np_xg real,
+    add column if not exists xa real,
+    add column if not exists xg_chain real,
+    add column if not exists xg_buildup real,
+    add column if not exists shots bigint,
+    add column if not exists key_passes bigint,
+    add column if not exists understat_id bigint;

--- a/Soccer Data Hub/supabase/migrations/0009_team_match_understat.sql
+++ b/Soccer Data Hub/supabase/migrations/0009_team_match_understat.sql
@@ -1,0 +1,30 @@
+-- Understat per-match team xG (2014+). Team names are Understat spellings —
+-- join to matches via date + the club-name seam, not by name equality.
+-- Apply manually in SQL editor.
+create table if not exists team_match_understat (
+    league text not null,
+    season text not null,
+    game_id bigint not null,
+    date date not null,
+    home_team text not null,
+    away_team text not null,
+    home_goals int,
+    away_goals int,
+    home_xg real,
+    away_xg real,
+    home_np_xg real,
+    away_np_xg real,
+    home_expected_points real,
+    away_expected_points real,
+    home_ppda real,
+    away_ppda real,
+    home_deep_completions int,
+    away_deep_completions int,
+    updated_at timestamptz not null default now(),
+    primary key (league, season, game_id)
+);
+
+alter table team_match_understat enable row level security;
+
+create policy "anon read only" on team_match_understat
+    for select to anon using (true);

--- a/Soccer Data Hub/supabase/migrations/0010_shots_understat.sql
+++ b/Soccer Data Hub/supabase/migrations/0010_shots_understat.sql
@@ -1,0 +1,29 @@
+-- Understat shot events (2014+): every shot with pitch coordinates and xG.
+-- Names/ids are Understat's own. ~630k rows across the Big-5 backfill.
+-- Apply manually in SQL editor.
+create table if not exists shots_understat (
+    league text not null,
+    season text not null,
+    shot_id bigint not null,
+    game_id bigint not null,
+    date date not null,
+    team text not null,
+    player text not null,
+    player_id bigint,
+    assist_player text,
+    assist_player_id bigint,
+    xg real,
+    location_x real,
+    location_y real,
+    minute int,
+    body_part text,
+    situation text,
+    result text,
+    updated_at timestamptz not null default now(),
+    primary key (league, season, shot_id)
+);
+
+alter table shots_understat enable row level security;
+
+create policy "anon read only" on shots_understat
+    for select to anon using (true);

--- a/Soccer Data Hub/tests/test_pipelines.py
+++ b/Soccer Data Hub/tests/test_pipelines.py
@@ -262,5 +262,6 @@ def test_public_exports():
     for fn in ("build_player_xref", "build_player_season",
                "push_to_supabase", "push_transfers", "push_age_curve",
                "push_matches", "push_club_elo", "push_club_elo_history",
+               "push_player_xg", "push_team_match", "push_shots",
                "run_season"):
         assert callable(getattr(soccerhub, fn))

--- a/Soccer Data Hub/tests/test_understat.py
+++ b/Soccer Data Hub/tests/test_understat.py
@@ -1,0 +1,142 @@
+import pandas as pd
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SOCCERHUB_CACHE", str(tmp_path))
+
+
+def _us(rows):
+    return pd.DataFrame(rows, columns=["player", "team", "minutes", "xg", "np_xg",
+                                       "xa", "xg_chain", "xg_buildup", "shots",
+                                       "key_passes", "player_id"])
+
+
+def _hub(rows):
+    return pd.DataFrame(rows, columns=["league", "season", "team",
+                                       "player_name", "minutes"])
+
+
+def test_match_players_ladder():
+    from soccerhub.pipelines.understat import match_players
+
+    us = _us([
+        # rung 1: unique name, spelling identical
+        ["Bukayo Saka", "Arsenal", 2900, 12.1, 9.3, 8.0, 20.0, 5.0, 90, 60, 7322],
+        # rung 2: mover — two stints, must pair by minutes
+        ["Cole Palmer", "Manchester City", 300, 1.0, 1.0, 0.5, 2.0, 1.0, 10, 5, 111],
+        ["Cole Palmer", "Chelsea", 2500, 20.0, 16.0, 10.0, 30.0, 4.0, 100, 70, 111],
+        # rung 3: accent drift (fbref has the accent, understat doesn't)
+        ["Martin Odegaard", "Arsenal", 2700, 8.0, 8.0, 7.5, 25.0, 8.0, 70, 80, 6055],
+        # no counterpart in hub: must stay unmatched
+        ["Ghost Player", "Nowhere FC", 900, 1.0, 1.0, 0.0, 1.0, 0.0, 5, 2, 999],
+    ])
+    hub = _hub([
+        ["ENG-Premier League", "2023", "Arsenal", "Bukayo Saka", 2919],
+        ["ENG-Premier League", "2023", "Manchester City", "Cole Palmer", 250],
+        ["ENG-Premier League", "2023", "Chelsea", "Cole Palmer", 2450],
+        ["ENG-Premier League", "2023", "Arsenal", "Martin Ødegaard", 2650],
+        ["ENG-Premier League", "2023", "Burnley", "Unrelated Person", 900],
+    ])
+    out = match_players(us, hub).set_index("player_name")
+
+    assert out.loc["Bukayo Saka", "understat_id"] == 7322
+    # mover stints attached to the right clubs
+    assert out.loc["Cole Palmer"].set_index("team").loc["Chelsea", "xg"] == 20.0
+    assert out.loc["Cole Palmer"].set_index("team").loc["Manchester City", "xg"] == 1.0
+    # accent drift caught by fuzzy rung
+    assert out.loc["Martin Ødegaard", "understat_id"] == 6055
+    # ghost row didn't invent a match
+    assert "Unrelated Person" not in out.index
+    assert len(out) == 4
+
+
+def test_match_players_minutes_guard_blocks_wrong_fuzzy():
+    from soccerhub.pipelines.understat import match_players
+
+    # near-identical names but wildly different minutes: must NOT match
+    us = _us([["Joao Silva", "Porto B", 2800, 5, 5, 2, 8, 2, 40, 20, 1]])
+    hub = _hub([["ESP-La Liga", "2023", "Sevilla", "Joao Silvo", 400]])
+    assert len(match_players(us, hub)) == 0
+
+
+def test_push_team_match_keys_and_season_label(monkeypatch, tmp_path):
+    import soccerhub.pipelines.understat as un
+    from soccerhub.manifest import Manifest
+
+    df = pd.DataFrame({
+        "game_id": [22275], "date": [pd.Timestamp("2023-08-11 19:00:00")],
+        "home_team": ["Burnley"], "away_team": ["Manchester City"],
+        "home_goals": [0], "away_goals": [3], "home_xg": [0.3], "away_xg": [2.5],
+        "home_np_xg": [0.3], "away_np_xg": [2.5],
+        "home_expected_points": [0.2], "away_expected_points": [2.7],
+        "home_ppda": [12.0], "away_ppda": [8.0],
+        "home_deep_completions": [2], "away_deep_completions": [14],
+        "league": ["ENG-Premier League"], "season": ["2324"],  # understat code
+    })
+    p = tmp_path / "tm.parquet"
+    df.to_parquet(p)
+    m = Manifest(path=str(p), source="understat", dataset="team_match",
+                 params={}, rows=1, cols=18, date_range=None, fetched_at="t")
+    monkeypatch.setattr(un, "fetch_understat",
+                        lambda l, s, d, force=False: m)
+
+    captured = {}
+
+    def fake_upsert(df, table, on_conflict):
+        captured["df"], captured["table"], captured["key"] = df, table, on_conflict
+        return len(df)
+
+    import soccerhub.pipelines.supa as sp
+    monkeypatch.setattr(sp, "upsert_df", fake_upsert)
+
+    assert un.push_team_match("ENG-Premier League", "2023") == 1
+    row = captured["df"].iloc[0]
+    assert captured["table"] == "team_match_understat"
+    assert captured["key"] == "league,season,game_id"
+    assert row["season"] == "2023"      # canonical, not understat's '2324'
+    assert row["date"] == "2023-08-11"  # date only, ISO
+    assert un.push_team_match("ENG-Premier League", "2010") == 0  # pre-2014
+
+
+def test_push_shots_keys_and_rounding(monkeypatch, tmp_path):
+    import soccerhub.pipelines.understat as un
+    from soccerhub.manifest import Manifest
+
+    df = pd.DataFrame({
+        "shot_id": [552237], "game_id": [22275],
+        "date": [pd.Timestamp("2023-08-11 19:00:00")],
+        "team": ["Burnley"], "player": ["Anass Zaroury"], "player_id": [11703],
+        "assist_player": ["Lyle Foster"], "assist_player_id": [10408],
+        "xg": [0.0639837458729744], "location_x": [0.817], "location_y": [0.536],
+        "minute": [79], "body_part": ["Left Foot"], "situation": ["Open Play"],
+        "result": ["Blocked Shot"],
+    })
+    p = tmp_path / "sh.parquet"
+    df.to_parquet(p)
+    m = Manifest(path=str(p), source="understat", dataset="shots",
+                 params={}, rows=1, cols=15, date_range=None, fetched_at="t")
+    monkeypatch.setattr(un, "fetch_understat", lambda l, s, d, force=False: m)
+
+    captured = {}
+
+    def fake_upsert(df, table, on_conflict):
+        captured["df"], captured["table"], captured["key"] = df, table, on_conflict
+        return len(df)
+
+    import soccerhub.pipelines.supa as sp
+    monkeypatch.setattr(sp, "upsert_df", fake_upsert)
+
+    assert un.push_shots("ENG-Premier League", "2023") == 1
+    row = captured["df"].iloc[0]
+    assert captured["table"] == "shots_understat"
+    assert captured["key"] == "league,season,shot_id"
+    assert row["xg"] == 0.064
+    assert row["season"] == "2023"
+
+
+def test_fetch_understat_rejects_unknown_dataset():
+    from soccerhub.readers.understat import fetch_understat
+    with pytest.raises(ValueError):
+        fetch_understat("ENG-Premier League", "2023", "keeper")


### PR DESCRIPTION
…, shots)

- readers/understat.py: one fetch fn, three grains, plain HTTP (no browser)
- push_player_xg: xG/npxG/xA/xG-chain/buildup/shots/key-passes merged onto player_season via a name-match ladder — exact name, mid-season mover stints paired by minutes agreement, fuzzy 0.90 floor with 450-min guard (Understat has no birth years); partial-column upsert keyed by hub identity so unmatched rows can't create orphans
- push_team_match: per-match team xG, npxG, expected points, PPDA, deep completions -> team_match_understat
- push_shots: every shot with coordinates/situation/body part ->
  shots_understat (~10.5k rows and ~3min fetch per league-season)
- migrations 0008-0010; understat cron job (needs: seasons), 2014+ guard