### PR TITLE
feat(soccerhub): LLM agent layer (Layer 3) — Gemini over MCP

### DIFF
--- a/Soccer Data Hub/pyproject.toml
+++ b/Soccer Data Hub/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=2.0",
     "pyarrow>=14",
     "supabase>=2",
+    "google-genai>=1.9",
 ]
 
 [project.optional-dependencies]

--- a/Soccer Data Hub/src/soccerhub/__init__.py
+++ b/Soccer Data Hub/src/soccerhub/__init__.py
@@ -1,5 +1,6 @@
 """soccerhub — unified fetch layer for open-source soccer data."""
 
+from soccerhub.agent import ask
 from soccerhub.errors import SoccerhubError
 from soccerhub.manifest import Manifest
 from soccerhub.readers.clubelo import fetch_club_elo_history, fetch_club_elo_snapshot
@@ -29,6 +30,7 @@ from soccerhub.pipelines import (
 )
 
 __all__ = [
+    "ask",
     "SoccerhubError",
     "Manifest",
     "fetch_club_elo_history",

--- a/Soccer Data Hub/src/soccerhub/agent.py
+++ b/Soccer Data Hub/src/soccerhub/agent.py
@@ -23,24 +23,36 @@ _SERVER = StdioServerParameters(
 )
 
 
-def ask(prompt: str, model: str = "gemini-3-flash-preview") -> str:
-    """Ask the soccerhub agent a question. Calls MCP tools as needed; returns text."""
+def ask(
+    prompt: str,
+    images: list[bytes] | None = None,
+    model: str = "gemini-3-flash-preview",
+) -> str:
+    """Ask the soccerhub agent a question. Calls MCP tools as needed; returns text.
+
+    images: optional PNG bytes (rendered chart screenshots) sent alongside the
+    prompt so the model reads the visual pattern, not just numbers in the text.
+    """
     try:
-        return asyncio.run(_run(prompt, model))
+        return asyncio.run(_run(prompt, images or [], model))
     except SoccerhubError:
         raise
     except Exception as e:  # API / transport / unrecovered tool error
         raise SoccerhubError(str(e)) from e
 
 
-async def _run(prompt: str, model: str) -> str:
+async def _run(prompt: str, images: list[bytes], model: str) -> str:
     client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    contents = prompt if not images else [
+        prompt,
+        *(types.Part.from_bytes(data=img, mime_type="image/png") for img in images),
+    ]
     async with stdio_client(_SERVER) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             resp = await client.aio.models.generate_content(
                 model=model,
-                contents=prompt,
+                contents=contents,
                 config=types.GenerateContentConfig(tools=[session]),
             )
     return resp.text

--- a/Soccer Data Hub/src/soccerhub/agent.py
+++ b/Soccer Data Hub/src/soccerhub/agent.py
@@ -1,0 +1,46 @@
+"""Layer 3: Gemini agent over the soccerhub MCP tools.
+
+``ask()`` spawns ``mcp_server.py`` as a stdio subprocess and lets Gemini call
+the registered tools (hub_table, fbref_season, ...) via the SDK's built-in MCP
+support — no hand-written tool schemas. Text in, text out.
+
+Needs ``GEMINI_API_KEY`` in the environment (same convention as SUPABASE_*).
+"""
+import asyncio
+import os
+import sys
+
+from google import genai
+from google.genai import types
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from soccerhub.errors import SoccerhubError
+
+# Run the MCP server as a subprocess of the current interpreter/venv.
+_SERVER = StdioServerParameters(
+    command=sys.executable, args=["-m", "soccerhub.mcp_server"]
+)
+
+
+def ask(prompt: str, model: str = "gemini-3-flash-preview") -> str:
+    """Ask the soccerhub agent a question. Calls MCP tools as needed; returns text."""
+    try:
+        return asyncio.run(_run(prompt, model))
+    except SoccerhubError:
+        raise
+    except Exception as e:  # API / transport / unrecovered tool error
+        raise SoccerhubError(str(e)) from e
+
+
+async def _run(prompt: str, model: str) -> str:
+    client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    async with stdio_client(_SERVER) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            resp = await client.aio.models.generate_content(
+                model=model,
+                contents=prompt,
+                config=types.GenerateContentConfig(tools=[session]),
+            )
+    return resp.text

--- a/Soccer Data Hub/src/soccerhub/mcp_server.py
+++ b/Soccer Data Hub/src/soccerhub/mcp_server.py
@@ -1,6 +1,8 @@
 from dataclasses import asdict
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ToolAnnotations
 
 from soccerhub.pipelines.query import read_hub
 from soccerhub.readers.fbref import fetch_fbref_season
@@ -9,8 +11,13 @@ from soccerhub.readers.transfermarkt import fetch_transfermarkt_values
 
 mcp = FastMCP("soccerhub")
 
+# All tools are pure reads. openWorld=True for tools that hit external
+# sites (FBref/StatsBomb/Transfermarkt); False for hub_table (own Supabase).
+_READ_CLOSED = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+_READ_OPEN = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True)
 
-@mcp.tool()
+
+@mcp.tool(annotations=_READ_CLOSED)
 def hub_table(
     table: str,
     select: str = "*",
@@ -26,25 +33,37 @@ def hub_table(
         for k, v in {"league": league, "season": season, "tm_id": tm_id}.items()
         if v is not None
     }
-    return read_hub(table, select, **filters).head(max_rows).to_dict("records")
+    try:
+        return read_hub(table, select, **filters).head(max_rows).to_dict("records")
+    except Exception as e:  # surface an actionable message to the model caller
+        raise ToolError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_OPEN)
 def fbref_season(league: str, season: str) -> dict:
     """Fetch + cache FBref player season stats; returns a manifest."""
-    return asdict(fetch_fbref_season(league, season))
+    try:
+        return asdict(fetch_fbref_season(league, season))
+    except Exception as e:
+        raise ToolError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_OPEN)
 def statsbomb_events(match_id: str) -> dict:
     """Fetch + cache StatsBomb open-data match events; returns a manifest."""
-    return asdict(fetch_statsbomb_events(match_id))
+    try:
+        return asdict(fetch_statsbomb_events(match_id))
+    except Exception as e:
+        raise ToolError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_OPEN)
 def transfermarkt_values(competition: str) -> dict:
     """Fetch + cache Transfermarkt valuations for a competition; returns a manifest."""
-    return asdict(fetch_transfermarkt_values(competition))
+    try:
+        return asdict(fetch_transfermarkt_values(competition))
+    except Exception as e:
+        raise ToolError(str(e)) from e
 
 
 if __name__ == "__main__":

--- a/Soccer Data Hub/tests/test_agent.py
+++ b/Soccer Data Hub/tests/test_agent.py
@@ -1,0 +1,80 @@
+"""Wiring smoke test for the Layer-3 agent. No live API / subprocess.
+
+Mocks the genai client + MCP stdio/session boundaries; asserts ask() passes
+the prompt as contents, hands the session straight into tools=[session], and
+returns the model's text — and that failures surface as SoccerhubError.
+"""
+import pytest
+
+from soccerhub.errors import SoccerhubError
+
+
+class _ACM:
+    """Minimal async context manager yielding a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _AsyncCall:
+    """Async callable that records kwargs and returns (or raises) a fixed result."""
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    async def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def _wire(monkeypatch, gen_result):
+    """Patch agent's genai/stdio/session boundaries. Returns (session, gen_call)."""
+    from soccerhub import agent
+
+    async def _init():
+        return None
+
+    session = type("Session", (), {"initialize": staticmethod(_init)})()
+    monkeypatch.setattr(agent, "stdio_client", lambda server: _ACM((None, None)))
+    monkeypatch.setattr(agent, "ClientSession", lambda read, write: _ACM(session))
+
+    gen = _AsyncCall(gen_result)
+    client = type("Client", (), {})()
+    client.aio = type("Aio", (), {})()
+    client.aio.models = type("Models", (), {"generate_content": gen})()
+    fake_genai = type("genai", (), {"Client": staticmethod(lambda api_key: client)})
+    monkeypatch.setattr(agent, "genai", fake_genai)
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    return session, gen
+
+
+def test_ask_returns_model_text(monkeypatch):
+    resp = type("Resp", (), {"text": "Messi leads with 12 xG."})()
+    session, gen = _wire(monkeypatch, resp)
+
+    from soccerhub.agent import ask
+
+    out = ask("who leads La Liga in xG?")
+
+    assert out == "Messi leads with 12 xG."
+    kwargs = gen.calls[0]
+    assert kwargs["contents"] == "who leads La Liga in xG?"
+    assert kwargs["config"].tools == [session]  # session handed straight to tools
+
+
+def test_ask_wraps_errors(monkeypatch):
+    _wire(monkeypatch, ValueError("boom"))
+
+    from soccerhub.agent import ask
+
+    with pytest.raises(SoccerhubError):
+        ask("q")

--- a/Soccer Data Hub/tests/test_agent.py
+++ b/Soccer Data Hub/tests/test_agent.py
@@ -71,6 +71,20 @@ def test_ask_returns_model_text(monkeypatch):
     assert kwargs["config"].tools == [session]  # session handed straight to tools
 
 
+def test_ask_sends_images(monkeypatch):
+    resp = type("Resp", (), {"text": "The radar shows an elite passer."})()
+    _session, gen = _wire(monkeypatch, resp)
+
+    from soccerhub.agent import ask
+
+    out = ask("interpret this chart", images=[b"\x89PNG-fake-bytes"])
+
+    assert out == "The radar shows an elite passer."
+    contents = gen.calls[0]["contents"]
+    assert contents[0] == "interpret this chart"  # prompt first
+    assert len(contents) == 2  # prompt + one image Part
+
+
 def test_ask_wraps_errors(monkeypatch):
     _wire(monkeypatch, ValueError("boom"))
 

--- a/docs/plans/2026-07-23-llm-agent-layer-design.md
+++ b/docs/plans/2026-07-23-llm-agent-layer-design.md
@@ -1,0 +1,202 @@
+# Soccer Data Hub — LLM Agent Layer (Layer 3) — Design Spec
+
+_Plan · Project #2 addendum · created 2026-07-23_
+
+## Overview
+
+`soccerhub`'s design doc (`2026-07-14-soccerhub-data-layer-design.md`) scoped a
+three-layer architecture and explicitly deferred Layer 3 ("LLM agent over MCP")
+as future work. Layer 1 (readers/pipelines) and Layer 2 (`mcp_server.py`) are
+built and in production use (player card xG, hub queries). This spec adds
+Layer 3: a Gemini-backed agent, `soccerhub.agent.ask()`, that answers
+natural-language questions over hub data, interprets charts (data + rendered
+image), and generates summaries — by calling the *existing* MCP tools, no new
+data pipeline.
+
+## Goals
+
+- One function, `ask(prompt, images=None) -> str`, covering all three use
+  cases (data query, chart interpretation, summary generation) — they're the
+  same shape (text/image in, model decides whether to call a tool, text out).
+- Zero duplication of tool logic: the agent calls `mcp_server.py`'s tools as
+  an MCP client, it does not re-import Layer 1 or redefine schemas.
+- Backend-first: importable/CLI-runnable now; site wiring (`player.html`
+  button → HTTP endpoint → `ask()`) is explicitly out of scope for this spec.
+
+## Non-goals (explicit YAGNI)
+
+- HTTP endpoint / web wiring for `site/*.html`.
+- Conversation memory or multi-turn session state across separate `ask()` calls.
+- Streaming responses.
+- Non-Gemini providers / fallback routing.
+- Renaming existing MCP tool names (`hub_table`, `fbref_season`, etc.) — Layer 2
+  is shipped; renaming breaks nothing to fix, so it stays snake_case as-is.
+
+## Architecture
+
+```
+Layer 1  soccerhub readers/pipelines        ← unchanged
+Layer 2  mcp_server.py (FastMCP, stdio)     ← unchanged tools, adds annotations
+                                               + ToolError wrapping (this spec)
+Layer 3  soccerhub/agent.py  ask()          ← NEW: Gemini + MCP client
+```
+
+`ask()` spawns `mcp_server.py` as a stdio subprocess, opens an
+`mcp.ClientSession`, and passes that session directly into
+`google-genai`'s `generate_content(tools=[session])`. The SDK's built-in MCP
+support handles `tools/list` discovery, schema translation, and the
+`FunctionCall` ↔ `tools/call` round-trip — no hand-written tool schemas.
+
+## Data flow
+
+```
+CALLER
+  ask(prompt, images=[])
+        │
+        ▼
+  build contents: [text Part(prompt), image Part(png)...]   ← only if images passed
+        │
+        ▼
+  spawn mcp_server.py (stdio subprocess) ──► mcp.ClientSession
+        │                                         │
+        │                              lists 4 registered tools:
+        │                              hub_table / fbref_season /
+        │                              statsbomb_events / transfermarkt_values
+        ▼
+  genai.Client.generate_content(model, contents, tools=[session])
+        │
+        ▼
+  Gemini decides: answer directly, or call a tool? ──┐
+        │                                            │
+   NO TOOL NEEDED                              TOOL CALL NEEDED
+   (chart/data interpretation,                  (data-hub query, e.g.
+    summary from data in prompt)                 "compare these 2 wingers")
+        │                                            │
+        │                                            ▼
+        │                              MCP routes call to matching tool fn
+        │                                            │
+        │                       ┌────────────────────┼─────────────────────┐
+        │                       ▼                    ▼                     ▼
+        │                 hub_table(...)      fbref_season(...)   statsbomb_events(...)
+        │                 read_hub()           fetch_fbref_season() fetch_statsbomb_events()
+        │                       │                    │                     │
+        │                 Supabase REST        Layer-1 reader        Layer-1 reader
+        │                 (source of truth)    cache_key() lookup    cache_key() lookup
+        │                       │              ┌─────┴─────┐         ┌─────┴─────┐
+        │                       │           HIT│           │MISS  HIT│           │MISS
+        │                       │              ▼           ▼         ▼           ▼
+        │                       │        read parquet  soccerdata  read parquet kloppy
+        │                       │        (instant)     call+cache  (instant)    call+cache
+        │                       │              │           │         │           │
+        │                       │              └─────┬─────┘         └─────┬─────┘
+        │                       │                     ▼                    ▼
+        │                       │                Manifest/dict      Manifest/dict
+        │                       └──────────┬──────────┴────────────────────┘
+        │                                  ▼
+        │                       tool result returned to Gemini
+        │                                  │
+        │                                  ▼
+        │                       Gemini reads result → may call
+        │                       another tool, or produce final answer
+        │                                  │
+        └──────────────────┬───────────────┘
+                            ▼
+                  final text response
+                            │
+                            ▼
+                       return str
+
+ERROR PATHS (either branch):
+  tool raises SoccerhubError → mcp_server.py re-raises as ToolError(str(e))
+      → surfaced to Gemini as an actionable message (not masked), model may
+      retry with corrected args or explain the failure to the caller
+  MCP subprocess dies / transport error → ask() raises SoccerhubError
+  Gemini API error (rate limit / auth) → ask() raises SoccerhubError
+  cache write mid-fetch fails → existing Layer-1 atomic-write guarantee holds
+      (unchanged from Layer 1 design, no poisoned cache)
+```
+
+## Interface
+
+```python
+# src/soccerhub/agent.py
+def ask(
+    prompt: str,
+    images: list[bytes] | None = None,
+    model: str = "gemini-2.5-flash",
+) -> str:
+    """Ask the soccerhub agent a question. Calls MCP tools as needed."""
+```
+
+- `images`: optional list of PNG bytes (rendered chart screenshots), sent as
+  multimodal `Part`s alongside the text prompt — Gemini reads both the
+  underlying data (passed in `prompt`) and the visual pattern in the image.
+- Raises `SoccerhubError` on any failure (API, transport, or an unrecovered
+  tool error) — same convention as Layer 1 readers.
+- One function covers all three use cases; which one happens is a function of
+  what the caller puts in `prompt`/`images`, not a code branch.
+
+## MCP server changes (`mcp_server.py`)
+
+Two additions to the 4 existing tools, no behavior change to their logic:
+
+1. **Tool annotations** — all 4 tools are pure reads:
+   ```python
+   from mcp.types import ToolAnnotations
+
+   @mcp.tool(annotations=ToolAnnotations(
+       readOnlyHint=True, destructiveHint=False, openWorldHint=False))
+   def hub_table(...):   # reads own Supabase — closed world
+
+   @mcp.tool(annotations=ToolAnnotations(
+       readOnlyHint=True, destructiveHint=False, openWorldHint=True))
+   def fbref_season(...):        # scrapes external site — open world
+   def statsbomb_events(...):    # same
+   def transfermarkt_values(...): # same
+   ```
+2. **Error wrapping** — catch `SoccerhubError`, re-raise as
+   `mcp.server.fastmcp.exceptions.ToolError` so Gemini gets an actionable
+   message instead of FastMCP's default masked generic error:
+   ```python
+   from mcp.server.fastmcp.exceptions import ToolError
+
+   @mcp.tool(annotations=...)
+   def statsbomb_events(match_id: str) -> dict:
+       try:
+           return asdict(fetch_statsbomb_events(match_id))
+       except SoccerhubError as e:
+           raise ToolError(str(e)) from e
+   ```
+
+Confirmed against installed `mcp==1.28.1`: `FastMCP.tool()` accepts
+`annotations: ToolAnnotations`, and `ToolError` is importable — no version
+bump needed for this.
+
+## Config & dependencies
+
+- New env var `GEMINI_API_KEY`, same pattern as existing `SUPABASE_*` vars
+  (exported in shell / sourced `.env`, no dotenv library — matches repo
+  convention, see `pipelines/supa.py`).
+- `pyproject.toml`: add `google-genai>=1.9` (first version with stable MCP
+  `ClientSession` passthrough).
+
+## Testing
+
+One smoke test, `tests/test_agent.py`, matching the repo's "one test per unit"
+pattern (`tests/test_cache.py`, `tests/test_understat.py`): mock the
+`genai.Client` and `mcp.ClientSession`, assert `ask()` builds the correct
+`Part` list (text, or text+image) and returns the mocked model's text. No real
+API calls in tests — this is a wiring test, not an eval of Gemini's answers.
+
+## Key decisions
+
+| Concern | Decision | Rationale |
+|---|---|---|
+| LLM provider | Google Gemini free tier | AWS Bedrock / Azure OpenAI have no real free inference tier (trial credits only); Gemini free tier + native multimodal covers chart-image interpretation |
+| Tool wiring | MCP client against existing `mcp_server.py` | Matches original Layer-3-over-MCP design; zero duplicate tool schemas; same server also usable by Claude Desktop/other MCP clients later |
+| Interface shape | One function `ask(prompt, images=None)` | All three use cases (query/chart/summary) are the same text-and-optional-image-in, text-out shape — no reason to branch in code |
+| Chart interpretation input | Both structured data (in prompt) and rendered screenshot (image) | User wants the model reading numbers and visual pattern, not one or the other |
+| MCP tool naming | Unchanged (`hub_table`, `fbref_season`, ...) | Already shipped; renaming has no functional benefit and risks breaking other MCP clients |
+| New code naming | snake_case, prefer one-word names (`ask`) | Matches repo's PEP8 convention; user asked for concise naming, not camelCase |
+| Site wiring | Deferred | User chose backend-first; needs a real backend host since `site/*.html` is static + direct Supabase calls today, no server to add an endpoint to yet |
+| Tool annotations / error wrapping | Add to `mcp_server.py` now | Prerequisite for a *model* being the caller instead of a human — masked/vague errors block the model's ability to self-correct (e.g. retry a bad `match_id`) |

--- a/docs/plans/2026-07-23-llm-agent-layer-design.md
+++ b/docs/plans/2026-07-23-llm-agent-layer-design.md
@@ -123,7 +123,7 @@ ERROR PATHS (either branch):
 def ask(
     prompt: str,
     images: list[bytes] | None = None,
-    model: str = "gemini-2.5-flash",
+    model: str = "gemini-3-flash-preview",
 ) -> str:
     """Ask the soccerhub agent a question. Calls MCP tools as needed."""
 ```


### PR DESCRIPTION
## What

Adds Layer 3 from the soccerhub design: a Gemini-backed agent that answers
questions, interprets charts, and writes summaries by driving the **existing**
MCP tools — no new data pipeline, no duplicated tool schemas.

`soccerhub.ask(prompt, images=None, model="gemini-3-flash-preview") -> str`

Spawns `mcp_server.py` as a stdio subprocess and hands the live MCP session
straight into the google-genai SDK's native MCP support (`tools=[session]`),
which drives the `tools/list` → `FunctionCall` → `tools/call` loop for us.

## Changes

**MCP server hardening** (prereq for a model caller)
- `ToolAnnotations` on all 4 tools — `readOnlyHint=True`; `openWorldHint=True`
  for the FBref/StatsBomb/Transfermarkt scrapers, `False` for `hub_table`
  (own Supabase).
- Tool bodies wrap failures as `ToolError` so the model gets an actionable
  message instead of FastMCP's default masked error.

**Agent layer**
- New `agent.py` — sync `ask()` over an async core; any API/transport/tool
  failure surfaces as `SoccerhubError`.
- Multimodal: `images=[png bytes]` sends rendered chart screenshots as Gemini
  Parts alongside the prompt (visual pattern + underlying numbers).
- `google-genai>=1.9` added; `ask` exported from the package root.

## Testing

- 3 mocked wiring smoke tests (contents building, session→tools passthrough,
  image Parts, error mapping). No live API calls.
- Full suite: 56/56 pass.

## Not verified / follow-ups

- **Live Gemini call is untested** (needs `GEMINI_API_KEY` + confirming the
  native model id resolves). Everything up to the API boundary is mocked.
- Deferred (per spec): site wiring (`player.html` button → HTTP endpoint →
  `ask()`), conversation memory, streaming.

Design spec: `docs/plans/2026-07-23-llm-agent-layer-design.md`