### PR TITLE
fix: surface real agent error (unwrap ExceptionGroup) + Netlify publi…

### DIFF
--- a/Soccer Data Hub/src/soccerhub/agent.py
+++ b/Soccer Data Hub/src/soccerhub/agent.py
@@ -40,6 +40,14 @@ def _tool_result_text(result) -> str:
     return "".join(getattr(c, "text", "") for c in result.content)
 
 
+def _root_cause(exc: BaseException) -> BaseException:
+    """Unwrap anyio/asyncio ExceptionGroups to the real leaf exception, so the
+    error message is actionable instead of 'unhandled errors in a TaskGroup'."""
+    while (subs := getattr(exc, "exceptions", None)):
+        exc = subs[0]
+    return exc
+
+
 def ask(
     prompt: str,
     images: list[bytes] | None = None,
@@ -55,7 +63,8 @@ def ask(
     except SoccerhubError:
         raise
     except Exception as e:  # API / transport / unrecovered tool error
-        raise SoccerhubError(str(e)) from e
+        cause = _root_cause(e)
+        raise SoccerhubError(f"{type(cause).__name__}: {cause}") from e
 
 
 async def _run(prompt: str, images: list[bytes], model: str) -> str:

--- a/Soccer Data Hub/tests/test_agent.py
+++ b/Soccer Data Hub/tests/test_agent.py
@@ -142,6 +142,14 @@ def test_ask_runs_tool_loop(monkeypatch):
     assert len(gen.calls[1]["contents"]) > 1  # fed the tool response back
 
 
+def test_root_cause_unwraps_exception_group():
+    from soccerhub.agent import _root_cause
+
+    leaf = KeyError("GEMINI_API_KEY")
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [leaf])
+    assert _root_cause(group) is leaf
+
+
 def test_server_config():
     # Guards the two integration fixes live testing surfaced:
     from soccerhub import agent

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+# Netlify reads this from the repo root. Serve the static site from site/, and
+# proxy /api/ask to the Render backend (same-origin, no CORS, URL hidden).
+[build]
+  publish = "site"
+
+[[redirects]]
+  from = "/api/ask"
+  to = "https://soccerhub-agent.onrender.com/ask"
+  status = 200
+  force = true

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,8 +1,0 @@
-# Proxy the site's /api/ask to the Render backend so the browser calls a
-# same-origin path (no CORS, backend URL stays out of the frontend).
-# Replace the Render URL below with your deployed service URL.
-[[redirects]]
-  from = "/api/ask"
-  to = "https://soccerhub-agent.onrender.com/ask"
-  status = 200
-  force = true


### PR DESCRIPTION
…sh dir

- agent.ask() unwraps anyio/asyncio ExceptionGroups to the leaf exception, so failures return the real cause instead of 'unhandled errors in a TaskGroup'.
- Move netlify.toml to repo root with publish="site" so Netlify serves the static site (was 404 — files live in site/, not repo root).